### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@
           }
         },
         {
-          "uses": "actions/checkout@v3.5.0"
+          "uses": "actions/checkout@v3.5.2"
         },
         {
           "run": "(git gc || :)"
@@ -29,7 +29,7 @@
       "runs-on": "${{ matrix.os }}",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.0"
+          "uses": "actions/checkout@v3.5.2"
         },
         {
           "run": "(git gc || :)"
@@ -53,13 +53,13 @@
       "runs-on": "ubuntu-latest",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.0"
+          "uses": "actions/checkout@v3.5.2"
         },
         {
           "run": "(git gc || :)"
         },
         {
-          "uses": "jirutka/setup-alpine@v1.1.1",
+          "uses": "jirutka/setup-alpine@v1.1.3",
           "with": {
             "arch": "${{ matrix.alpinearch }}",
             "branch": "edge",

--- a/.github/workflows/gha-update.yml
+++ b/.github/workflows/gha-update.yml
@@ -4,7 +4,7 @@
       "runs-on": "ubuntu-latest",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.0",
+          "uses": "actions/checkout@v3.5.2",
           "with": {
             "token": "${{ secrets.WORKFLOW_SECRET }}"
           }

--- a/.github/workflows/vm-dfbsd.yml
+++ b/.github/workflows/vm-dfbsd.yml
@@ -4,7 +4,7 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.0"
+          "uses": "actions/checkout@v3.5.2"
         },
         {
           "run": "(git gc || :)"

--- a/.github/workflows/vm-fbsd.yml
+++ b/.github/workflows/vm-fbsd.yml
@@ -4,13 +4,13 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.0"
+          "uses": "actions/checkout@v3.5.2"
         },
         {
           "run": "(git gc || :)"
         },
         {
-          "uses": "vmactions/freebsd-vm@v0.0.7",
+          "uses": "vmactions/freebsd-vm@v0.3.0",
           "with": {
             "copyback": false,
             "mem": 2048,

--- a/.github/workflows/vm-nbsd.yml
+++ b/.github/workflows/vm-nbsd.yml
@@ -4,7 +4,7 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.0"
+          "uses": "actions/checkout@v3.5.2"
         },
         {
           "run": "(git gc || :)"

--- a/.github/workflows/vm-obsd.yml
+++ b/.github/workflows/vm-obsd.yml
@@ -4,7 +4,7 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.0"
+          "uses": "actions/checkout@v3.5.2"
         },
         {
           "run": "(git gc || :)"

--- a/.github/workflows/vm-slowlartus.yml
+++ b/.github/workflows/vm-slowlartus.yml
@@ -4,7 +4,7 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.0"
+          "uses": "actions/checkout@v3.5.2"
         },
         {
           "run": "(git gc || :)"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[vmactions/freebsd-vm](https://github.com/vmactions/freebsd-vm)** published a new release **[v0.3.0](https://github.com/vmactions/freebsd-vm/releases/tag/v0.3.0)** on 2022-11-02T15:15:59Z
* **[jirutka/setup-alpine](https://github.com/jirutka/setup-alpine)** published a new release **[v1.1.3](https://github.com/jirutka/setup-alpine/releases/tag/v1.1.3)** on 2023-04-12T10:18:59Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.2](https://github.com/actions/checkout/releases/tag/v3.5.2)** on 2023-04-13T12:49:40Z
