### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@
           }
         },
         {
-          "uses": "actions/checkout@v3.5.2"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"
@@ -29,7 +29,7 @@
       "runs-on": "${{ matrix.os }}",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.2"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"
@@ -53,7 +53,7 @@
       "runs-on": "ubuntu-latest",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.2"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"

--- a/.github/workflows/gha-update.yml
+++ b/.github/workflows/gha-update.yml
@@ -4,13 +4,13 @@
       "runs-on": "ubuntu-latest",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.2",
+          "uses": "actions/checkout@v3.5.3",
           "with": {
             "token": "${{ secrets.WORKFLOW_SECRET }}"
           }
         },
         {
-          "uses": "saadmk11/github-actions-version-updater@v0.7.4",
+          "uses": "saadmk11/github-actions-version-updater@v0.8.0",
           "with": {
             "pull_request_user_reviewers": "mirabilos",
             "token": "${{ secrets.WORKFLOW_SECRET }}"

--- a/.github/workflows/vm-dfbsd.yml
+++ b/.github/workflows/vm-dfbsd.yml
@@ -4,7 +4,7 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.2"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"

--- a/.github/workflows/vm-fbsd.yml
+++ b/.github/workflows/vm-fbsd.yml
@@ -4,13 +4,13 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.2"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"
         },
         {
-          "uses": "vmactions/freebsd-vm@v0.3.0",
+          "uses": "vmactions/freebsd-vm@v0.3.1",
           "with": {
             "copyback": false,
             "mem": 2048,

--- a/.github/workflows/vm-nbsd.yml
+++ b/.github/workflows/vm-nbsd.yml
@@ -4,7 +4,7 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.2"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"

--- a/.github/workflows/vm-obsd.yml
+++ b/.github/workflows/vm-obsd.yml
@@ -4,7 +4,7 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.2"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"

--- a/.github/workflows/vm-slowlartus.yml
+++ b/.github/workflows/vm-slowlartus.yml
@@ -4,7 +4,7 @@
       "runs-on": "macos-12",
       "steps": [
         {
-          "uses": "actions/checkout@v3.5.2"
+          "uses": "actions/checkout@v3.5.3"
         },
         {
           "run": "(git gc || :)"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[vmactions/freebsd-vm](https://github.com/vmactions/freebsd-vm)** published a new release **[v0.3.1](https://github.com/vmactions/freebsd-vm/releases/tag/v0.3.1)** on 2023-06-25T12:10:43Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.3](https://github.com/actions/checkout/releases/tag/v3.5.3)** on 2023-06-09T15:05:56Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.0](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.0)** on 2023-08-06T06:09:30Z
