### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gha-update.yml
+++ b/.github/workflows/gha-update.yml
@@ -10,7 +10,7 @@
           }
         },
         {
-          "uses": "saadmk11/github-actions-version-updater@v0.8.0",
+          "uses": "saadmk11/github-actions-version-updater@v0.8.1",
           "with": {
             "ignore": "github/codeql-action/init@v2,github/codeql-action/analyze@v2",
             "pull_request_user_reviewers": "mirabilos",


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
